### PR TITLE
The separator is now disabled and cannot be selected from the dropdown

### DIFF
--- a/dist/ng-country-select.js
+++ b/dist/ng-country-select.js
@@ -764,7 +764,10 @@
         only: '@csOnly',
         except: '@csExcept'
       },
-      template: '<select ng-options="country.code as country.name for country in countries"> <option value="" ng-if="isSelectionOptional"></option> </select>',
+      template: '<select>' +
+                  '<option value="" ng-if="isSelectionOptional"></option>' +
+                  '<option ng-repeat="country in ::countries" value="{{country.code}}" ng-disabled="country.disabled">{{country.name}}</option>' +
+                '</select>',
       controller: [
         '$scope', '$attrs', function($scope, $attrs) {
           var countryCodesIn, findCountriesIn, includeOnlyRequestedCountries, removeCountry, removeExcludedCountries, separator, updateWithPriorityCountries;


### PR DESCRIPTION
Prior to my changes, the separator that appears as a result of the cs-priorities attribute could be selected (which is meaningless). The disabled property is in the separator object but was not being used by an ng-disabled in the markup. This resolves that problem.
