### PR TITLE
Update spelling of country name.

### DIFF
--- a/src/ng-country-select.coffee
+++ b/src/ng-country-select.coffee
@@ -6,7 +6,7 @@ angular
     { code: 'AL', name: 'Albania' },
     { code: 'DZ', name: 'Algeria' },
     { code: 'AS', name: 'American Samoa' },
-    { code: 'AD', name: 'Andorre' },
+    { code: 'AD', name: 'Andorra' },
     { code: 'AO', name: 'Angola' },
     { code: 'AI', name: 'Anguilla' },
     { code: 'AQ', name: 'Antarctica' },


### PR DESCRIPTION
Andorra was mispelt in English.
